### PR TITLE
Get reviews by username

### DIFF
--- a/api/app/controllers/review.controller.js
+++ b/api/app/controllers/review.controller.js
@@ -48,10 +48,20 @@ exports.findAll = async (req, res) => {
   let username = req.query.username !== "undefined" ? req.query.username : undefined
   
   // find reviews by username
-  if (Boolean(username)) {
-    const foundUser = await User.findOne({ where: { githubUsername: username }})
-    if (foundUser?.dataValues?.id) {
-      userId = foundUser?.dataValues?.id;
+  if (username) {
+    try {
+      const foundUser = await User.findOne({ where: { githubUsername: username }});
+      if (foundUser?.dataValues?.id) {
+        userId = foundUser?.dataValues?.id;
+      } else {
+        return res.status(404).send({
+          message: `User with username=${username} does not exist`
+        });
+      }
+    } catch (err) {
+      return res.status(500).send({
+        message: err.message || `Some error occurred while getting user with username=${username}`
+      });
     }
   }
 
@@ -72,10 +82,10 @@ exports.findAll = async (req, res) => {
 
   Review.findAll({ where: groupedCondition, include: { model: Transcript }})
     .then(data => {
-      res.send(data);
+      return res.send(data);
     })
     .catch(err => {
-      res.status(500).send({
+      return res.status(500).send({
         message:
           err.message || "Some error occurred while retrieving reviews."
       });

--- a/api/app/controllers/review.controller.js
+++ b/api/app/controllers/review.controller.js
@@ -82,10 +82,10 @@ exports.findAll = async (req, res) => {
 
   Review.findAll({ where: groupedCondition, include: { model: Transcript }})
     .then(data => {
-      return res.send(data);
+      res.send(data);
     })
     .catch(err => {
-      return res.status(500).send({
+      res.status(500).send({
         message:
           err.message || "Some error occurred while retrieving reviews."
       });

--- a/api/app/controllers/review.controller.js
+++ b/api/app/controllers/review.controller.js
@@ -43,10 +43,12 @@ exports.create = (req, res) => {
 
 // Retrieve all reviews from the database.
 exports.findAll = async (req, res) => {
-  let { userId, username, isActive} = req.query
-
+  let {isActive} = req.query
+  let userId = req.query.userId !== "undefined" ? parseInt(req.query.userId) : undefined
+  let username = req.query.username !== "undefined" ? req.query.username : undefined
+  
   // find reviews by username
-  if (username) {
+  if (Boolean(username)) {
     const foundUser = await User.findOne({ where: { githubUsername: username }})
     if (foundUser?.dataValues?.id) {
       userId = foundUser?.dataValues?.id;
@@ -59,7 +61,7 @@ exports.findAll = async (req, res) => {
   const userIdCondition = { userId: { [Op.eq]: userId } }
 
   // add condition if query exists
-  if (userId) {
+  if (Boolean(userId)) {
     groupedCondition = {...groupedCondition, ...userIdCondition}
   }
   if (isActive === "true") {

--- a/api/app/utils/review.inference.js
+++ b/api/app/utils/review.inference.js
@@ -3,14 +3,15 @@ const db = require("../sequelize/models");
 const Op = db.Sequelize.Op;
 
 const unixEpochTimeInMilliseconds = getUnixTimeFromHours(config.expiryTimeInHours)
+const timeStringAt24HoursPrior = new Date(new Date().getTime() - unixEpochTimeInMilliseconds).toISOString()
 const isActiveCondition = { 
   mergedAt: { [Op.eq]: null },
-  createdAt: { [Op.gte]: new Date().getTime() - unixEpochTimeInMilliseconds }
+  createdAt: { [Op.gte]: timeStringAt24HoursPrior }
 };
 
 const isInActiveCondition = {
   [Op.or]: [
-    { createdAt: { [Op.lt]: new Date().getTime() - unixEpochTimeInMilliseconds } },
+    { createdAt: { [Op.lt]: timeStringAt24HoursPrior } },
     { mergedAt: { [Op.not]: null } }
   ]
 }


### PR DESCRIPTION
Fixes:
- Previous implementation for active review inference compared dateString (e.g 2023-05-13T20:50:22.896Z) with date difference in milliseconds. fixed - comparison is done with 2 dateStrings instead.

Feat:
- Don't run query whose values are undefined
- Throw error for invalid username, this is useful in building public profile page. If a username is not associated with a user throw a not found error. Whereas if the user exists but without reviews the response is an empty array. Previously invalid users return all reviews

Closes #37 