### PR TITLE
chore: add admin middleware

### DIFF
--- a/api/app/controllers/user.controller.ts
+++ b/api/app/controllers/user.controller.ts
@@ -78,12 +78,11 @@ export function findAll(req: Request, res: Response) {
     ? { username: { [Op.iLike]: `%${username.toString()}%` } }
     : {};
 
-  User.findAll({ where: condition })
+  User.findAll({
+    where: condition,
+    attributes: { exclude: ["jwt", "albyToken", "email", "updatedAt"] },
+  })
     .then((data) => {
-      data.forEach((user) => {
-        user.jwt = undefined;
-        user.albyToken = undefined;
-      });
       return res.send(data);
     })
     .catch((err) => {

--- a/api/app/controllers/user.controller.ts
+++ b/api/app/controllers/user.controller.ts
@@ -96,7 +96,9 @@ export function findAll(req: Request, res: Response) {
 export function findOne(req: Request, res: Response) {
   const id = Number(req.params.id);
 
-  User.findByPk(id)
+  User.findByPk(id, {
+    attributes: { exclude: ["jwt", "albyToken", "email", "updatedAt"] },
+  })
     .then((data) => {
       return res.send(data);
     })

--- a/api/app/middleware/validate-github-token.ts
+++ b/api/app/middleware/validate-github-token.ts
@@ -20,7 +20,7 @@ const validateGitHubToken = async (
   }
 
   if (!email) {
-    return res.status(404).json({ error: "Unauthorized. No email provided!" });
+    return res.status(400).json({ error: "Bad Input. No email provided!" });
   }
 
   try {

--- a/api/app/routes/transcript.routes.ts
+++ b/api/app/routes/transcript.routes.ts
@@ -167,7 +167,7 @@ export function transcriptRoutes(app: Express) {
    */
 
   // Create a new transcript
-  router.post("/", auth, transcripts.create);
+  router.post("/", auth, admin, transcripts.create);
 
   // Retrieve all transcripts
   router.get("/", transcripts.findAll);

--- a/api/app/routes/user.routes.ts
+++ b/api/app/routes/user.routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import express from "express";
 import * as users from "../controllers/user.controller";
-import { auth } from "../middleware/auth";
+import { admin, auth } from "../middleware/auth";
 import validateGitHubToken from "../middleware/validate-github-token";
 
 export function userRoutes(app: Express) {
@@ -86,7 +86,7 @@ export function userRoutes(app: Express) {
    *                         description: Date when a user record is updated.
    *                         example: 2023-03-08T13:42:08.699Z
    */
-  router.get("/", auth, users.findAll);
+  router.get("/", auth, admin, users.findAll);
 
   // Retrieve a single User with id
   /**


### PR DESCRIPTION
closes https://github.com/bitcointranscripts/transcription-review-backend/issues/135

task:
- [x] only admins can get all users
- [x] user data returned to the client now only includes `id` `githubUsername`, `permissions`, `createdAt`, `archivedAt`. Other sensitive data has been stripped off.
- [x] only admin can create a transcript