### PR TITLE
Configure auth on swagger for `/transcripts` and `/reviews` routes

### DIFF
--- a/api/app/controllers/transcript.controller.ts
+++ b/api/app/controllers/transcript.controller.ts
@@ -203,14 +203,17 @@ export async function findOne(req: Request, res: Response) {
 
   await Transcript.findByPk(id)
     .then(async (data) => {
-      if (data) {
-        res.send(data);
+      if (!data) {
+        return res.status(404).send({
+          message: `Transcript with id=${id} does not exist`,
+        });
       }
+      res.status(200).send(data);
     })
     .catch((err) => {
       console.log(err);
-      res.status(404).send({
-        message: "Could not find Transcript with id=" + id,
+      res.status(500).send({
+        message: `Error retrieving Transcript with id=${id}`,
       });
     });
 }

--- a/api/app/routes/review.routes.ts
+++ b/api/app/routes/review.routes.ts
@@ -28,6 +28,8 @@ export function reviewRoutes(app: Express) {
    *   description: The reviews API routes
    * /api/reviews:
    *   get:
+   *     security:
+   *       - bearerAuth: []
    *     summary: Lists all the reviews
    *     tags: [Reviews]
    *     parameters:
@@ -61,6 +63,8 @@ export function reviewRoutes(app: Express) {
    *       500:
    *         description: Some error occurred while retrieving reviews
    *   post:
+   *     security:
+   *       - bearerAuth: []
    *     summary: Create a new review
    *     tags: [Reviews]
    *     requestBody:
@@ -80,6 +84,8 @@ export function reviewRoutes(app: Express) {
    *         description: Some server error
    * /api/reviews/{id}:
    *   get:
+   *     security:
+   *       - bearerAuth: []
    *     summary: Get the review by id
    *     tags: [Reviews]
    *     parameters:
@@ -99,6 +105,8 @@ export function reviewRoutes(app: Express) {
    *       404:
    *         description: The review was not found
    *   put:
+   *    security:
+   *      - bearerAuth: []
    *    summary: Update the review by the id
    *    tags: [Reviews]
    *    parameters:
@@ -128,6 +136,8 @@ export function reviewRoutes(app: Express) {
    *
    * /api/reviews/{id}/submit:
    *   put:
+   *     security:
+   *       - bearerAuth: []
    *    summary: Submit the review by the id
    *    tags: [Reviews]
    *    parameters:

--- a/api/app/routes/transcript.routes.ts
+++ b/api/app/routes/transcript.routes.ts
@@ -9,6 +9,10 @@ export function transcriptRoutes(app: Express) {
   /**
    * @swagger
    * components:
+   *   securitySchemes:
+   *    bearerAuth:
+   *      type: http
+   *      scheme: bearer  
    *   schemas:
    *     Archive:
    *       type: object
@@ -25,6 +29,8 @@ export function transcriptRoutes(app: Express) {
    *         originalContent:
    *           type: object
    *           description: Original content that should not be changed
+   * security:
+   *  - bearerAuth: []
    */
 
   /**
@@ -46,6 +52,8 @@ export function transcriptRoutes(app: Express) {
    *               items:
    *                 $ref: '#/components/schemas/Transcript'
    *   post:
+   *     security:
+   *       - bearerAuth: []
    *     summary: Create a new transcript
    *     tags: [Transcripts]
    *     requestBody:
@@ -65,6 +73,8 @@ export function transcriptRoutes(app: Express) {
    *         description: Some server error
    * /api/transcripts/{id}:
    *   get:
+   *     security:
+   *       - bearerAuth: []
    *     summary: Get the transcript by id
    *     tags: [Transcripts]
    *     parameters:
@@ -77,13 +87,15 @@ export function transcriptRoutes(app: Express) {
    *     responses:
    *       200:
    *         description: The transcript response by id
-   *         contens:
+   *         content:
    *           application/json:
    *             schema:
    *               $ref: '#/components/schemas/Transcript'
    *       404:
    *         description: The transcript was not found
    *   put:
+   *    security:
+   *      - bearerAuth: []
    *    summary: Update the transcript by the id
    *    tags: [Transcripts]
    *    parameters:
@@ -112,6 +124,8 @@ export function transcriptRoutes(app: Express) {
    *        description: Some error happened
    * /api/transcripts/{id}/archive:
    *   put:
+   *    security:
+   *      - bearerAuth: []
    *    summary: Archive the transcript by the id
    *    tags: [Transcripts]
    *    parameters:
@@ -140,6 +154,8 @@ export function transcriptRoutes(app: Express) {
    *        description: Some error happened
    * /api/transcripts/{id}/claim:
    *   put:
+   *    security:
+   *      - bearerAuth: []
    *    summary: Claim the transcript by the id
    *    tags: [Transcripts]
    *    parameters:


### PR DESCRIPTION
This makes swagger usable after the introduction of authentication on the backend + a small bugfix that I stumbled upon. Details on commit messages.
