### PR TITLE
increase maximum request body size to 1mb

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -44,7 +44,7 @@ const specs = swaggerJsdoc(options);
 
 const app = express();
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: "1mb" }));
 app.use(express.urlencoded({ extended: true }));
 app.use(
   "/api/docs",


### PR DESCRIPTION
default request body size is 100kb, which is an issue for larger transcripts