### PR TITLE
Swagger additions

### DIFF
--- a/api/app/routes/review.routes.ts
+++ b/api/app/routes/review.routes.ts
@@ -19,6 +19,11 @@ export function reviewRoutes(app: Express) {
    *         transcriptId:
    *           type: integer
    *           description: Id of the transcript that gets reviewed
+   * 
+   *     Pagination:
+   *       type: integer
+   *       minimum: 1
+   *       default: 1
    */
 
   /**
@@ -199,10 +204,11 @@ export function reviewRoutes(app: Express) {
    *     tags: [Reviews]
    *     parameters:
    *       - in: query
-   *         name: submittedAt
+   *         name: status
    *         schema:
    *           type: string
-   *         description: Filter reviews based on submittedAt
+   *           enum: [expired, pending, active]
+   *         description: Filter reviews based on status
    *       - in: query
    *         name: transcriptId
    *         schema:
@@ -223,6 +229,10 @@ export function reviewRoutes(app: Express) {
    *         schema:
    *           type: string
    *         description: Filter reviews based on mergedAt
+   *       - in: query
+   *         name: page
+   *         schema:
+   *           $ref: '#/components/schemas/Pagination'
    *     responses:
    *       200:
    *         description: The list of reviews

--- a/api/server.ts
+++ b/api/server.ts
@@ -36,6 +36,12 @@ const options = {
       {
         url: "http://localhost:8080",
       },
+      {
+        url: "https://transcription-review-backend-staging.up.railway.app"
+      },
+      {
+        url: "https://queue.btctranscripts.com"
+      }
     ],
   },
   apis: ["./app/routes/*.ts"],

--- a/api/server.ts
+++ b/api/server.ts
@@ -8,7 +8,6 @@ import {
 } from "sequelize";
 import swaggerJsdoc from "swagger-jsdoc";
 import swaggerUi from "swagger-ui-express";
-
 import {
   logout,
   reviewRoutes,
@@ -23,6 +22,24 @@ import { Logger } from "./app/helpers/logger";
 
 dotenv.config();
 
+const environment = process.env.NODE_ENV;
+
+let serverUrl;
+switch (environment) {
+  case 'development':
+    serverUrl = "http://localhost:8080";
+    break;
+  case 'staging':
+    serverUrl = "https://transcription-review-backend-staging.up.railway.app";
+    break;
+  case 'production':
+    serverUrl = "https://queue.btctranscripts.com";
+    break;
+  default:
+    serverUrl = "http://localhost:8080";
+    break;
+}
+
 const options = {
   definition: {
     openapi: "3.0.0",
@@ -34,14 +51,8 @@ const options = {
     },
     servers: [
       {
-        url: "http://localhost:8080",
+        url: serverUrl,
       },
-      {
-        url: "https://transcription-review-backend-staging.up.railway.app"
-      },
-      {
-        url: "https://queue.btctranscripts.com"
-      }
     ],
   },
   apis: ["./app/routes/*.ts"],


### PR DESCRIPTION
#241 added a new parameter to `/api/reviews/all` but did not update swagger.

This PR also adds
- staging and production as server options to make it easier to test.
- the paging parameter to the `/api/reviews/all` endpoint to make it easier to test.
