### PR TITLE
fix: claimedBy value in webhook controller

### DIFF
--- a/api/app/controllers/webhook.controller.ts
+++ b/api/app/controllers/webhook.controller.ts
@@ -143,7 +143,7 @@ export async function create(req: Request, res: Response) {
       );
 
       if (associatedTranscript) {
-        associatedTranscript.claimedBy = undefined;
+        associatedTranscript.claimedBy = null;
         associatedTranscript.status = TranscriptStatus.queued;
         await associatedTranscript?.save();
         res.sendStatus(200);


### PR DESCRIPTION
The db expects a constraint value of null and not undefined. This pr fixes the claimedBy value of the transcript when we recieve a pull request event on `action: closed`.