### PR TITLE
fix: refactor credit transaction process in webhook controller

### DIFF
--- a/api/app/controllers/webhook.controller.ts
+++ b/api/app/controllers/webhook.controller.ts
@@ -1,15 +1,9 @@
 import { Request, Response } from "express";
 import axios from "axios";
-import { Review, Transaction, Wallet, Transcript, User } from "../db/models";
-import { sequelize } from "../db";
-import { TRANSACTION_STATUS, TRANSACTION_TYPE } from "../types/transaction";
+import { Review, Transcript } from "../db/models";
 import { TranscriptAttributes, TranscriptStatus } from "../types/transcript";
 import { PR_EVENT_ACTIONS } from "../utils/constants";
 
-import {
-  calculateCreditAmount,
-  generateTransactionId,
-} from "../utils/transaction";
 import { verify_signature } from "../utils/validate-webhook-signature";
 import { parseMdToJSON } from "../helpers/transcript";
 import { getTotalWords } from "../utils/review.inference";
@@ -17,53 +11,10 @@ import { sendAlert } from "../helpers/sendAlert";
 import { cacheTranscript } from "../db/helpers/redis";
 import { BaseParsedMdContent } from "../types/transcript";
 import { isTranscriptValid } from "../utils/functions";
-
-// create a new credit transaction when a review is merged
-async function createCreditTransaction(review: Review, amount: number) {
-  const dbTransaction = await sequelize.transaction();
-  const currentTime = new Date();
-
-  const user = await User.findByPk(review.userId);
-  if (!user) throw new Error(`Could not find user with id=${review.userId}`);
-
-  const userWallet = await Wallet.findOne({
-    where: { userId: user.id },
-  });
-  if (!userWallet)
-    throw new Error(`Could not get wallet for user with id=${user.id}`);
-
-  const newWalletBalance = userWallet.balance + Math.round(+amount);
-  const creditTransaction = {
-    id: generateTransactionId(),
-    reviewId: review.id,
-    walletId: userWallet.id,
-    amount: Math.round(+amount),
-    transactionType: TRANSACTION_TYPE.CREDIT,
-    transactionStatus: TRANSACTION_STATUS.SUCCESS,
-    timestamp: currentTime,
-  };
-  try {
-    await Transaction.create(creditTransaction, {
-      transaction: dbTransaction,
-    });
-    await userWallet.update(
-      {
-        balance: newWalletBalance,
-      },
-      { transaction: dbTransaction }
-    );
-    await dbTransaction.commit();
-  } catch (error) {
-    await dbTransaction.rollback();
-    const failedTransaction = {
-      ...creditTransaction,
-      transactionStatus: TRANSACTION_STATUS.FAILED,
-    };
-    await Transaction.create(failedTransaction);
-
-    throw error;
-  }
-}
+import {
+  addCreditTransactionQueue,
+  startBackgroundTaskForCreditTransaction,
+} from "../utils/cron";
 
 export async function create(req: Request, res: Response) {
   if (!verify_signature(req)) {
@@ -114,11 +65,13 @@ export async function create(req: Request, res: Response) {
       if (associatedTranscript) {
         associatedTranscript.archivedAt = currentTime;
         await associatedTranscript?.save();
+        await addCreditTransactionQueue(associatedTranscript, existingReview);
 
-        const creditAmount = await calculateCreditAmount(associatedTranscript);
-        await createCreditTransaction(existingReview, creditAmount);
-
-        return res.sendStatus(200);
+        return res
+          .status(200)
+          .send({
+            message: `processing credit transaction for review ${existingReview.id}`,
+          });
       } else {
         throw new Error("Could not find associated transcript");
       }
@@ -246,29 +199,34 @@ async function processCommit(
         await cacheTranscript(transcriptData);
 
         // Send alert to Discord
-        sendAlert(
-          "New Transcript Ready for Review!",
-          false,
-          transcriptData.originalContent.title,
-          transcriptData.originalContent.speakers,
-          transcriptData.transcriptUrl
-        );
+        sendAlert({
+          message: "New Transcript Ready for Review!",
+          isError: false,
+          transcriptTitle: transcriptData.originalContent.title,
+          speakers: transcriptData.originalContent.speakers,
+          transcriptUrl: transcriptData.transcriptUrl,
+          type: "transcript",
+        });
       } else if (type === "modified" && existingTranscript) {
         await existingTranscript.update(transcript);
         transcriptData = existingTranscript;
         await cacheTranscript(transcriptData);
 
         // Send alert to Discord
-        sendAlert(
-          "Transcript modified",
-          false,
-          transcriptData.originalContent.title,
-          transcriptData.originalContent.speakers,
-          transcriptData.transcriptUrl
-        );
+        sendAlert({
+          message: "Transcript modified",
+          isError: false,
+          transcriptTitle: transcriptData.originalContent.title,
+          speakers: transcriptData.originalContent.speakers,
+          transcriptUrl: transcriptData.transcriptUrl,
+          type: "transcript",
+        });
       }
     } catch (error: any) {
-      sendAlert(`Error processing file ${result.file}: ${error.message}`, true);
+      sendAlert({
+        message: `Error processing file ${result.file}: ${error.message}`,
+        isError: true,
+      });
     }
   }
 }
@@ -290,7 +248,7 @@ function isValidEnvironmentAndBranch(branch: string, env: string): boolean {
 // Handle errors and send alerts
 async function handleError(error: any, res: Response) {
   const message = error instanceof Error ? error.message : "Unknown error";
-  sendAlert(message, true);
+  sendAlert({ message, isError: true });
   return res.status(500).json({ message: message });
 }
 
@@ -329,7 +287,7 @@ export async function handlePushEvent(req: Request, res: Response) {
         await processCommit(commit, pushEvent, "added", branch);
         await processCommit(commit, pushEvent, "modified", branch);
       } catch (error: any) {
-        sendAlert(error.message, true);
+        sendAlert({ message: error.message, isError: true });
         res.status(500).json({ message: error.message });
         return { status: "rejected", reason: error.message };
       }

--- a/api/app/utils/transaction.ts
+++ b/api/app/utils/transaction.ts
@@ -1,3 +1,6 @@
+import { sequelize } from "../db";
+import { Review, Transaction, User, Wallet } from "../db/models";
+import { TRANSACTION_STATUS, TRANSACTION_TYPE } from "../types/transaction";
 import { TranscriptAttributes } from "../types/transcript";
 import { SATS_REWARD_RATE_PER_WORD } from "./constants";
 import { calculateWordDiff } from "./review.inference";
@@ -9,7 +12,9 @@ function generateTransactionId() {
   return timestamp + randomString;
 }
 
-async function calculateCreditAmount(associatedTranscript: TranscriptAttributes) {
+async function calculateCreditAmount(
+  associatedTranscript: TranscriptAttributes
+) {
   const { totalDiff, totalWords } = await calculateWordDiff(
     associatedTranscript
   );
@@ -19,4 +24,56 @@ async function calculateCreditAmount(associatedTranscript: TranscriptAttributes)
   return creditAmount;
 }
 
-export { generateTransactionId, calculateCreditAmount };
+// create a new credit transaction when a review is merged
+async function createCreditTransaction(review: Review, amount: number) {
+  const dbTransaction = await sequelize.transaction();
+  const currentTime = new Date();
+
+  const user = await User.findByPk(review.userId);
+  if (!user) throw new Error(`Could not find user with id=${review.userId}`);
+
+  const userWallet = await Wallet.findOne({
+    where: { userId: user.id },
+  });
+  if (!userWallet)
+    throw new Error(`Could not get wallet for user with id=${user.id}`);
+
+  const newWalletBalance = userWallet.balance + Math.round(+amount);
+  const creditTransaction = {
+    id: generateTransactionId(),
+    reviewId: review.id,
+    walletId: userWallet.id,
+    amount: Math.round(+amount),
+    transactionType: TRANSACTION_TYPE.CREDIT,
+    transactionStatus: TRANSACTION_STATUS.SUCCESS,
+    timestamp: currentTime,
+  };
+  try {
+    await Transaction.create(creditTransaction, {
+      transaction: dbTransaction,
+    });
+    await userWallet.update(
+      {
+        balance: newWalletBalance,
+      },
+      { transaction: dbTransaction }
+    );
+    await dbTransaction.commit();
+    return creditTransaction;
+  } catch (error) {
+    await dbTransaction.rollback();
+    const failedTransaction = {
+      ...creditTransaction,
+      transactionStatus: TRANSACTION_STATUS.FAILED,
+    };
+    await Transaction.create(failedTransaction);
+
+    throw error;
+  }
+}
+
+export {
+  generateTransactionId,
+  calculateCreditAmount,
+  createCreditTransaction,
+};

--- a/api/app/utils/wordDiffWorker.js
+++ b/api/app/utils/wordDiffWorker.js
@@ -1,0 +1,30 @@
+const { parentPort, workerData } = require("worker_threads");
+// we have to import the functions from the dist folder's file
+// because the worker is running in a separate process and
+// it doesn't have access to the same scope as the main process
+// and the dist folder is the compiled version of the app
+// so we have to import the functions from the compiled version of the app
+const {
+  createCreditTransaction,
+  calculateCreditAmount,
+} = require("../../dist/app/utils/transaction");
+
+async function processJob({ transcript, review }) {
+  try {
+    const creditAmount = await calculateCreditAmount(transcript);
+    const transactionResult = await createCreditTransaction(
+      review,
+      creditAmount
+    );
+    parentPort.postMessage({ success: true, transactionResult });
+  } catch (error) {
+    parentPort.postMessage({
+      success: false,
+      error:
+        error.message ||
+        "An error occurred while processing the transaction job.",
+    });
+  }
+}
+
+processJob(workerData);

--- a/api/package.json
+++ b/api/package.json
@@ -16,9 +16,9 @@
   "scripts": {
     "start": "ts-node server.ts",
     "tsc": "tsc -w",
-    "dev": "nodemon NODE_ENV=development server.ts",
-    "clean": "rm -rf dist && true",
     "build": "yarn run clean && tsc",
+    "dev": "yarn build && nodemon NODE_ENV=development server.ts",
+    "clean": "rm -rf dist && true",
     "migrate": "npx sequelize db:migrate",
     "migrate:undo": "npx sequelize db:migrate:undo",
     "seed": "npx sequelize db:seed:all"


### PR DESCRIPTION
This pr fixes the timeout issue when a review pr is merged in the btc transcript repo. Sometimes, the content diff is too large that the function to create the credit transaction takes longer than usual to resolve. And due to Javascript single threaded nature, it blocks the main server from processing incoming requests asynchronously until the expensive function is resolved.
This commit proposes a hot fix (a much better should follow) which utilises NodeJs thread workers and Redis queueing system to asynchronously allocate memory on another thread separate from the main server thread to run the credit transaction process. This approach ensures the webhook response is almost instant while the transaction process is queued in the redis cache and once each transaction job is resolved, it clears from the queue and moves on to the other job.

For errors that might occur during this process, the sendAlert function has been modified to accomodate transaction alerts sents to the discord bot. Only failed transaction alerts are notified as there is currently no reason to implement successful alert notification except on the user side (i.e. to user emails- should be in another pr)