### PR TITLE
fix: docker relative part for worker

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -17,9 +17,12 @@ RUN chmod 777 node_modules
 
 RUN yarn build
 
+COPY ./app/utils/wordDiffWorker.js ./dist/app/utils/wordDiffWorker.js
+
 ARG DB_URL=DB_URL
 ARG PORT=PORT
 ARG NODE_ENV=NODE_ENV
+ENV APP_PATH=/usr/src/app/dist/app/utils/
 
 EXPOSE 8080/tcp
 

--- a/api/app/utils/wordDiffWorker.js
+++ b/api/app/utils/wordDiffWorker.js
@@ -1,4 +1,6 @@
 const { parentPort, workerData } = require("worker_threads");
+const path = require('path');
+const appPath = process.env.APP_PATH || '../../dist/app';
 // we have to import the functions from the dist folder's file
 // because the worker is running in a separate process and
 // it doesn't have access to the same scope as the main process
@@ -7,7 +9,7 @@ const { parentPort, workerData } = require("worker_threads");
 const {
   createCreditTransaction,
   calculateCreditAmount,
-} = require("../../dist/app/utils/transaction");
+} = require(path.join(appPath, 'transaction'));
 
 async function processJob({ transcript, review }) {
   try {


### PR DESCRIPTION
This PR provides a hot fix for the docker issue for the worker thread which is used in activating credit after a review has been merged.