### PR TITLE
fix: unknown discord alert error

### DIFF
--- a/api/app/controllers/webhook.controller.ts
+++ b/api/app/controllers/webhook.controller.ts
@@ -221,6 +221,7 @@ async function processCommit(
       sendAlert({
         message: `Error processing file ${result.file}: ${error.message}`,
         isError: true,
+        type: "transcript",
       });
     }
   }
@@ -243,7 +244,7 @@ function isValidEnvironmentAndBranch(branch: string, env: string): boolean {
 // Handle errors and send alerts
 async function handleError(error: any, res: Response) {
   const message = error instanceof Error ? error.message : "Unknown error";
-  sendAlert({ message, isError: true });
+  sendAlert({ message, isError: true, type: "transcript"});
   return res.status(500).json({ message: message });
 }
 
@@ -282,7 +283,7 @@ export async function handlePushEvent(req: Request, res: Response) {
         await processCommit(commit, pushEvent, "added", branch);
         await processCommit(commit, pushEvent, "modified", branch);
       } catch (error: any) {
-        sendAlert({ message: error.message, isError: true });
+        sendAlert({ message: error.message, isError: true, type: "transcript"});
         res.status(500).json({ message: error.message });
         return { status: "rejected", reason: error.message };
       }


### PR DESCRIPTION
we sometimes get unknown error alert even for transcripts. This pr ensures we always send a transcript alert type where necessary.