### PR TITLE
feat: add credit review transaction endpoint and process unpaid review transactions

### DIFF
--- a/api/app/controllers/transaction.controller.ts
+++ b/api/app/controllers/transaction.controller.ts
@@ -1,10 +1,12 @@
 import { Request, Response } from "express";
 import { Op } from "sequelize";
 
-import { Review, Transaction, User, Wallet } from "../db/models";
+import { Review, Transaction, Transcript, User, Wallet } from "../db/models";
 import { TRANSACTION_STATUS, TRANSACTION_TYPE } from "../types/transaction";
 import { DB_START_PAGE, DB_TXN_QUERY_LIMIT } from "../utils/constants";
 import { generateTransactionId } from "../utils/transaction";
+import { addCreditTransactionQueue } from "../utils/cron";
+import { Logger } from "../helpers/logger";
 
 // Create and Save a new Transaction
 export async function create(req: Request, res: Response) {
@@ -277,5 +279,50 @@ export const getAllTransactions = async (req: Request, res: Response) => {
   } catch (error) {
     console.log(error);
     res.status(500).json({ message: "Internal server error" });
+  }
+};
+
+export const processUnpaidReviewTransaction = async (
+  req: Request,
+  res: Response
+) => {
+  const reviewId = req.body.reviewId;
+  if (!reviewId) {
+    return res.status(400).send({ message: "Review id is required" });
+  }
+  try {
+    const review = await Review.findByPk(reviewId);
+    if (!review) {
+      return res
+        .status(404)
+        .send({ message: `Review with id=${reviewId} not found` });
+    }
+    const unpaidReviewTransaction = await Transaction.findOne({
+      where: {
+        reviewId: reviewId,
+      },
+    });
+    if (unpaidReviewTransaction) {
+      return res
+        .status(200)
+        .send({ message: `Transaction for review - ${reviewId} already exists` });
+    }
+    const associatedTranscript = await Transcript.findByPk(review.transcriptId);
+    if (!associatedTranscript) {
+      return res.status(404).send({
+        message: `Transcript with id=${review.transcriptId} not found`,
+      });
+    }
+    await addCreditTransactionQueue(associatedTranscript, review);
+    return res
+      .status(200)
+      .send({
+        message: `Processing credit transaction for review ${reviewId}`,
+      });
+  } catch (error) {
+    Logger.error("Error in processing unpaid review transaction", error);
+    res
+      .status(500)
+      .send({ message: "Error processing unpaid review transaction" });
   }
 };

--- a/api/app/routes/review.routes.ts
+++ b/api/app/routes/review.routes.ts
@@ -249,29 +249,63 @@ export function reviewRoutes(app: Express) {
    *         description: Some error happened
    */
 
-/**
- * @swagger
- * /api/reviews/{id}/reset:
- *   post:
- *     security:
- *       - bearerAuth: []
- *     summary: Reset reviews for a transcript
- *     tags: [Reviews]
- *     parameters:
- *       - in: path
- *         name: id
- *         schema:
- *           type: string
- *         required: true
- *         description: The review id
- *     responses:
- *       200:
- *         description: The review was reset successfully
- *       404:
- *         description: Review was not found
- *       500:
- *         description: Some error happened
- */
+  /**
+   * @swagger
+   * /api/reviews/{id}/reset:
+   *   post:
+   *     security:
+   *       - bearerAuth: []
+   *     summary: Reset reviews for a transcript
+   *     tags: [Reviews]
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         schema:
+   *           type: string
+   *         required: true
+   *         description: The review id
+   *     responses:
+   *       200:
+   *         description: The review was reset successfully
+   *       404:
+   *         description: Review was not found
+   *       500:
+   *         description: Some error happened
+   */
+
+  /**
+   * @swagger
+   * /api/reviews/payment:
+   *   get:
+   *     security:
+   *       - bearerAuth: []
+   *     summary: Get paid or unpaid reviews
+   *     tags: [Reviews]
+   *     parameters:
+   *       - in: query
+   *         name: status
+   *         schema:
+   *           type: string
+   *           enum: [paid, unpaid]
+   *         description: Filter reviews based on status
+   *       - in: query
+   *         name: page
+   *         schema:
+   *           $ref: '#/components/schemas/Pagination'
+   *     responses:
+   *       200:
+   *         description: The list of reviews
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/components/schemas/Review'
+   *       404:
+   *         description: Review was not found.
+   *       500:
+   *         description: Some error happened
+   */
 
   // Create a new review
   router.post("/", reviews.create);
@@ -281,6 +315,8 @@ export function reviewRoutes(app: Express) {
 
   // Retrieve reviews for admin
   router.get("/all", admin, reviews.getAllReviewsForAdmin);
+  // get paid or unpaid reviews
+  router.get("/payment", admin, reviews.getReviewsByPaymentStatus);
 
   // Retrieve a single review with id
   router.get("/:id", reviews.findOne);

--- a/api/app/routes/transaction.routes.ts
+++ b/api/app/routes/transaction.routes.ts
@@ -81,6 +81,29 @@ export function transactionRoutes(app: Express) {
    *         description: Some server error
    */
 
+  /**
+   * @swagger
+   * /api/transaction/credit:
+   *   get:
+   *     security:
+   *       - bearerAuth: []
+   *     summary: process unpaid review transactions
+   *     tags: [Transactions]
+   *     parameters:
+   *       - in: query
+   *         name: reviewId
+   *         schema:
+   *           type: string
+   *         description: Id of the review
+   *     responses:
+   *       200:
+   *         description: The response for processing unpaid review transactions
+   *       404:
+   *         description: Bad request
+   *       500:
+   *         description: Error processing unpaid review transaction
+   */
+
   // Get Transaction
   router.get("/", transactions.findAll);
 
@@ -89,6 +112,9 @@ export function transactionRoutes(app: Express) {
 
   // Get all Transactions for Admin
   router.get("/all", admin, transactions.getAllTransactions);
+
+  // Process unpaid review transactions
+  router.post("/credit", admin, transactions.processUnpaidReviewTransaction);
 
   app.use("/api/transactions", auth, router);
 }


### PR DESCRIPTION
This commit adds two main functions - one for getting unpaid reviews from the db so as to have more visibility and the other for manually processing credit transactions for unpaid reviews.
unpaid reviews are reviews that have a mergedAt field which was not processed somehow by the webhook controller. We might consider creating a cron job for processing these reviews but that should be discussed carefully considering the caveats.