### PR TITLE
fix: expired condition not return merged reviews

### DIFF
--- a/api/app/utils/review.inference.ts
+++ b/api/app/utils/review.inference.ts
@@ -40,7 +40,7 @@ const buildIsExpiredAndArchivedCondition = (currentTime: number) => {
       createdAt: { [Op.lt]: timeStringAt24HoursPrior }, // expired
     },
   };
-}
+};
 
 const buildIsExpiredAndNotArchivedCondition = (currentTime: number) => {
   const timeStringAt24HoursPrior = new Date(
@@ -53,6 +53,14 @@ const buildIsExpiredAndNotArchivedCondition = (currentTime: number) => {
       submittedAt: { [Op.eq]: null }, // has not been submitted
       createdAt: { [Op.lt]: timeStringAt24HoursPrior }, // expired
     },
+  };
+};
+
+const buildIsExpiredAndArchivedOrNotArchivedCondition = (currentTime: number) => {
+  const expiredAndArchivedCondition = buildIsExpiredAndArchivedCondition(currentTime);
+  const expiredAndNotArchivedCondition = buildIsExpiredAndNotArchivedCondition(currentTime);
+  return {
+    [Op.or]: [expiredAndArchivedCondition, expiredAndNotArchivedCondition],
   };
 };
 
@@ -172,7 +180,7 @@ export const buildCondition = ({
         break;
 
       case 'expired':
-        const expiredCondition = buildIsExpiredAndArchivedCondition(currentTime);
+        const expiredCondition = buildIsExpiredAndArchivedOrNotArchivedCondition(currentTime);
         condition[Op.and as unknown as keyof typeof Op] = expiredCondition;
         break;
 

--- a/api/app/utils/review.inference.ts
+++ b/api/app/utils/review.inference.ts
@@ -45,6 +45,20 @@ const buildIsInActiveCondition = (currentTime: number) => {
   };
 };
 
+const buildIsExpiredAndArchivedCondition = (currentTime: number) => {
+  const timeStringAt24HoursPrior = new Date(
+    currentTime - unixEpochTimeInMilliseconds
+  ).toISOString();
+  return {
+    [Op.and]: {
+      mergedAt: { [Op.eq]: null }, // has not been merged
+      archivedAt: { [Op.not]: null }, // has been archived
+      submittedAt: { [Op.eq]: null }, // has not been submitted
+      createdAt: { [Op.lt]: timeStringAt24HoursPrior }, // expired
+    },
+  };
+}
+
 const buildIsExpiredAndNotArchivedCondition = (currentTime: number) => {
   const timeStringAt24HoursPrior = new Date(
     currentTime - unixEpochTimeInMilliseconds
@@ -175,7 +189,7 @@ export const buildCondition = ({
         break;
 
       case 'expired':
-        const expiredCondition = buildIsInActiveCondition(currentTime);
+        const expiredCondition = buildIsExpiredAndArchivedCondition(currentTime);
         condition[Op.and as unknown as keyof typeof Op] = expiredCondition;
         break;
 
@@ -277,6 +291,7 @@ export {
   buildIsActiveCondition,
   buildIsPendingCondition,
   buildIsInActiveCondition,
+  buildIsExpiredAndArchivedCondition,
   buildIsExpiredAndNotArchivedCondition,
   calculateWordDiff,
   getTotalWords,

--- a/api/app/utils/review.inference.ts
+++ b/api/app/utils/review.inference.ts
@@ -56,7 +56,10 @@ const buildIsExpiredAndNotArchivedCondition = (currentTime: number) => {
   };
 };
 
-const buildIsExpiredAndArchivedOrNotArchivedCondition = (currentTime: number) => {
+// This condition is used to get all expired reviews, whether they are archived or not.
+// Because we don't want to ignore expired reviews that has not yet been archived by the 
+// daily cron job.
+const buildIsExpiredCondition = (currentTime: number) => {
   const expiredAndArchivedCondition = buildIsExpiredAndArchivedCondition(currentTime);
   const expiredAndNotArchivedCondition = buildIsExpiredAndNotArchivedCondition(currentTime);
   return {
@@ -180,7 +183,7 @@ export const buildCondition = ({
         break;
 
       case 'expired':
-        const expiredCondition = buildIsExpiredAndArchivedOrNotArchivedCondition(currentTime);
+        const expiredCondition = buildIsExpiredCondition(currentTime);
         condition[Op.and as unknown as keyof typeof Op] = expiredCondition;
         break;
 

--- a/api/app/utils/review.inference.ts
+++ b/api/app/utils/review.inference.ts
@@ -28,23 +28,6 @@ const buildIsPendingCondition = () => {
   };
 };
 
-const buildIsInActiveCondition = (currentTime: number) => {
-  const timeStringAt24HoursPrior = new Date(
-    currentTime - unixEpochTimeInMilliseconds
-  ).toISOString();
-  return {
-    [Op.or]: {
-      mergedAt: { [Op.not]: null }, // has been merged
-      archivedAt: { [Op.not]: null }, // has been archived
-      // inactive conditions when review has expired
-      [Op.and]: {
-        createdAt: { [Op.lt]: timeStringAt24HoursPrior }, // expired
-        submittedAt: { [Op.eq]: null }, // has not been submitted
-      },
-    },
-  };
-};
-
 const buildIsExpiredAndArchivedCondition = (currentTime: number) => {
   const timeStringAt24HoursPrior = new Date(
     currentTime - unixEpochTimeInMilliseconds
@@ -290,7 +273,6 @@ export {
   getUnixTimeFromHours,
   buildIsActiveCondition,
   buildIsPendingCondition,
-  buildIsInActiveCondition,
   buildIsExpiredAndArchivedCondition,
   buildIsExpiredAndNotArchivedCondition,
   calculateWordDiff,


### PR DESCRIPTION
This pr fixes a bug where fetching expred reviews using the admin endpoint returns merged reviews as part of the data.
The pr refactors the expired condition to check only for expired reviews based on these conditions:
- mergedAt: null
- archivedAt: not null
- submittedAt: null
- createdAt: time elapsed since subsmission is greater than 24hrs

I also removed unused the buggy `buildIsInActiveCondition` since it is not used anywhere else in the code