### PR TITLE
feat: add evaluator role

### DIFF
--- a/api/app/controllers/user.controller.ts
+++ b/api/app/controllers/user.controller.ts
@@ -124,7 +124,7 @@ export function findOne(req: Request, res: Response) {
 }
 // Find a public user with github username
 export async function findByPublicProfile(req: Request, res: Response) {
-  const username = req.body.username;
+  const username = req.query.username as string;
 
   if (!username) throw new Error("Username is required");
 
@@ -143,7 +143,7 @@ export async function findByPublicProfile(req: Request, res: Response) {
       attributes: { exclude: baseExclusion },
     });
     if (!user) {
-      return res.status(500).send({
+      return res.status(400).send({
         message: "No User with username=" + username,
       });
     }

--- a/api/app/db/migrations/20240528111348-add-evaluator-user-permission.js
+++ b/api/app/db/migrations/20240528111348-add-evaluator-user-permission.js
@@ -1,0 +1,36 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+    // update the user table to add the evaluator permission to permissions enum column
+    await queryInterface.sequelize.query(`
+      ALTER TYPE "enum_users_permissions" ADD VALUE 'evaluator';
+    `);
+  },
+
+  async down (queryInterface, Sequelize) {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+    // remove the evaluator permission from the permissions enum column
+    await queryInterface.sequelize.query(`
+      DELETE FROM pg_enum
+      WHERE enumlabel = 'evaluator'
+      AND enumtypid = (
+        SELECT oid
+        FROM pg_type
+        WHERE typname = 'enum_users_permissions'
+      );
+    `);
+  }
+};

--- a/api/app/middleware/auth.ts
+++ b/api/app/middleware/auth.ts
@@ -46,3 +46,17 @@ export const admin = (req: Request, res: Response, next: NextFunction) => {
   }
   next();
 };
+
+export const evaluator = (req: Request, res: Response, next: NextFunction) => {
+  if (!req.body.userId || req.body.userPermissions !== USER_PERMISSIONS.EVALUATOR) {
+    return res.status(403).json({ error: "Evaluator role required" });
+  }
+  next();
+}
+
+export const adminOrEvaluator = (req: Request, res: Response, next: NextFunction) => {
+  if (!req.body.userId || (req.body.userPermissions !== USER_PERMISSIONS.ADMIN && req.body.userPermissions !== USER_PERMISSIONS.EVALUATOR)) {
+    return res.status(403).json({ error: "Admin or Evaluator role required" });
+  }
+  next();
+}

--- a/api/app/middleware/auth.ts
+++ b/api/app/middleware/auth.ts
@@ -40,23 +40,11 @@ export const auth = async (req: Request, res: Response, next: NextFunction) => {
   }
 };
 
-export const admin = (req: Request, res: Response, next: NextFunction) => {
-  if (!req.body.userId || req.body.userPermissions !== USER_PERMISSIONS.ADMIN) {
-    return res.status(403).json({ error: "Admin role required" });
-  }
-  next();
+export const authorizeRoles = (allowedRoles: USER_PERMISSIONS[]) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!req.body.userId || !allowedRoles.includes(req.body.userPermissions)) {
+      return res.status(403).json({ error: `${allowedRoles.join(' or ')} role required` });
+    }
+    next();
+  };
 };
-
-export const evaluator = (req: Request, res: Response, next: NextFunction) => {
-  if (!req.body.userId || req.body.userPermissions !== USER_PERMISSIONS.EVALUATOR) {
-    return res.status(403).json({ error: "Evaluator role required" });
-  }
-  next();
-}
-
-export const adminOrEvaluator = (req: Request, res: Response, next: NextFunction) => {
-  if (!req.body.userId || (req.body.userPermissions !== USER_PERMISSIONS.ADMIN && req.body.userPermissions !== USER_PERMISSIONS.EVALUATOR)) {
-    return res.status(403).json({ error: "Admin or Evaluator role required" });
-  }
-  next();
-}

--- a/api/app/routes/review.routes.ts
+++ b/api/app/routes/review.routes.ts
@@ -1,7 +1,8 @@
 import type { Express } from "express";
 import express from "express";
 import * as reviews from "../controllers/review.controller";
-import { admin, adminOrEvaluator, auth } from "../middleware/auth";
+import { authorizeRoles, auth } from "../middleware/auth";
+import { USER_PERMISSIONS } from "../types/user";
 
 export function reviewRoutes(app: Express) {
   const router = express.Router();
@@ -319,9 +320,9 @@ export function reviewRoutes(app: Express) {
   router.get("/", reviews.findAll);
 
   // Retrieve reviews for admin
-  router.get("/all", adminOrEvaluator, reviews.getAllReviewsForAdmin);
+  router.get("/all", authorizeRoles([USER_PERMISSIONS.ADMIN, USER_PERMISSIONS.EVALUATOR]), reviews.getAllReviewsForAdmin);
   // get paid or unpaid reviews
-  router.get("/payment", admin, reviews.getReviewsByPaymentStatus);
+  router.get("/payment", authorizeRoles([USER_PERMISSIONS.ADMIN]), reviews.getReviewsByPaymentStatus);
 
   // Retrieve a single review with id
   router.get("/:id", reviews.findOne);
@@ -332,7 +333,7 @@ export function reviewRoutes(app: Express) {
   // Submit a review with id
   router.put("/:id/submit", reviews.submit);
 
-  router.post("/:id/reset", admin, reviews.resetReviews);
+  router.post("/:id/reset", authorizeRoles([USER_PERMISSIONS.ADMIN]), reviews.resetReviews);
 
   app.use("/api/reviews", auth, router);
 }

--- a/api/app/routes/review.routes.ts
+++ b/api/app/routes/review.routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import express from "express";
 import * as reviews from "../controllers/review.controller";
-import { admin, auth } from "../middleware/auth";
+import { admin, adminOrEvaluator, auth } from "../middleware/auth";
 
 export function reviewRoutes(app: Express) {
   const router = express.Router();
@@ -319,7 +319,7 @@ export function reviewRoutes(app: Express) {
   router.get("/", reviews.findAll);
 
   // Retrieve reviews for admin
-  router.get("/all", admin, reviews.getAllReviewsForAdmin);
+  router.get("/all", adminOrEvaluator, reviews.getAllReviewsForAdmin);
   // get paid or unpaid reviews
   router.get("/payment", admin, reviews.getReviewsByPaymentStatus);
 

--- a/api/app/routes/transaction.routes.ts
+++ b/api/app/routes/transaction.routes.ts
@@ -1,7 +1,8 @@
 import type { Express } from "express";
 import express from "express";
 import * as transactions from "../controllers/transaction.controller";
-import { admin, auth } from "../middleware/auth";
+import { auth, authorizeRoles } from "../middleware/auth";
+import { USER_PERMISSIONS } from "../types/user";
 
 export function transactionRoutes(app: Express) {
   const router = express.Router();
@@ -115,10 +116,10 @@ export function transactionRoutes(app: Express) {
   router.post("/", transactions.create);
 
   // Get all Transactions for Admin
-  router.get("/all", admin, transactions.getAllTransactions);
+  router.get("/all", authorizeRoles([USER_PERMISSIONS.ADMIN]), transactions.getAllTransactions);
 
   // Process unpaid review transactions
-  router.post("/credit", admin, transactions.processUnpaidReviewTransaction);
+  router.post("/credit", authorizeRoles([USER_PERMISSIONS.ADMIN]), transactions.processUnpaidReviewTransaction);
 
   app.use("/api/transactions", auth, router);
 }

--- a/api/app/routes/transcript.routes.ts
+++ b/api/app/routes/transcript.routes.ts
@@ -1,7 +1,8 @@
 import type { Express } from "express";
 import express from "express";
 import * as transcripts from "../controllers/transcript.controller";
-import { admin, auth } from "../middleware/auth";
+import { auth, authorizeRoles } from "../middleware/auth";
+import { USER_PERMISSIONS } from "../types/user";
 
 export function transcriptRoutes(app: Express) {
   const router = express.Router();
@@ -183,7 +184,7 @@ export function transcriptRoutes(app: Express) {
    */
 
   // Create a new transcript
-  router.post("/", auth, admin, transcripts.create);
+  router.post("/", auth, authorizeRoles([USER_PERMISSIONS.ADMIN]), transcripts.create);
 
   // Retrieve all transcripts
   router.get("/", transcripts.findAll);
@@ -195,7 +196,7 @@ export function transcriptRoutes(app: Express) {
   router.put("/:id", auth, transcripts.update);
 
   // Archive a transcript with id
-  router.put("/:id/archive", auth, admin, transcripts.archive);
+  router.put("/:id/archive", auth, authorizeRoles([USER_PERMISSIONS.ADMIN]), transcripts.archive);
 
   // Claim a transcript with id
   router.put("/:id/claim", auth, transcripts.claim);

--- a/api/app/routes/user.routes.ts
+++ b/api/app/routes/user.routes.ts
@@ -201,64 +201,65 @@ export function userRoutes(app: Express) {
   /**
    * @swagger
    * /api/users/{id}:
-   *  tags: [Users]
-   *  put:
-   *    summary: Updates a JSONPlaceholder user.
-   *    description: Updates a single JSONPlaceholder user. Can be used to update a user profile when prototyping or testing an API.
+   *   put:
+   *    security:
+   *       - bearerAuth: []
+   *    tags: [Users]
+   *    summary: Updates a user profile.
+   *    description: Updates a user profile. Accessible only to admins. Can be used to update user permissions or Github username or both.
    *    parameters:
    *      - in: path
    *        name: id
    *        required: true
+   *        description: ID of the user to update.
    *        schema:
-   *          type: integer
-   *        description: Numeric ID of the user to update.
-   *      - in: query
-   *        name: username
-   *        required: true
-   *        schema:
-   *          type: string
-   *        description: The user's github username.
+   *         type: integer
+   *    requestBody:
+   *      required: true
+   *      content:
+   *        application/json:
+   *         schema:
+   *          type: object
+   *          properties:
+   *           permissions:
+   *              type: string
+   *              description: The user's permissions - either "admin" or "reviewer" or "evaluator".
+   *              enum: [admin, reviewer, evaluator]
+   *           githubUsername:
+   *              type: string
+   *              description: The user's Github username.
+   *              example: adamJonas
    *    responses:
    *      200:
    *        description: Update the records of a single user.
    *        content:
    *          application/json:
+   *           schema:
+   *            type: String
+   *            example: User updated successfully
+   *      404:
+   *        description: The user was not found.
+   *        content:
+   *          application/json:
+   *           schema:
+   *            type: String
+   *            example: User not found
+   *      400:
+   *        description: The user id is missing or the username is missing.
+   *        content:
+   *          application/json:
    *            schema:
-   *              type: object
-   *              properties:
-   *                 data:
-   *                   type: object
-   *                   properties:
-   *                     id:
-   *                       type: integer
-   *                       description: The user ID.
-   *                       example: 1
-   *                     githubUsername:
-   *                       type: string
-   *                       description: The user's Github username.
-   *                       example: ryanofsky
-   *                     authToken:
-   *                       type: string
-   *                       description: The user's authentication token.
-   *                       example: Thsdfk3j3kflfjdkfjfj
-   *                     permissions:
-   *                       type: string
-   *                       description: The user's permissions.
-   *                       enum: [admin, reviewer]
-   *                     archivedAt:
-   *                       type: datetime
-   *                       description: Date when a user is marked as inactive.
-   *                       example: 2023-03-08T13:42:08.699Z
-   *                     createdAt:
-   *                       type: datetime
-   *                       description: Date when a user is created
-   *                       example: 2023-03-08T13:42:08.699Z
-   *                     updatedAt:
-   *                       type: datetime
-   *                       description: Date when a user record is updated.
-   *                       example: 2023-03-08T13:42:08.699Z
+   *             type: String
+   *             example: Either permissions or githubUsername should be present!
+   *      500:
+   *        description: An error occurred while updating the user.
+   *        content:
+   *          application/json:
+   *           schema:
+   *            type: String
+   *            example: Cannot update User with id=1.
    */
-  router.put("/:id", auth, users.update);
+  router.put("/:id", auth, admin, users.update);
 
   app.use("/api/users", router);
 }

--- a/api/app/routes/user.routes.ts
+++ b/api/app/routes/user.routes.ts
@@ -1,8 +1,9 @@
 import type { Express } from "express";
 import express from "express";
 import * as users from "../controllers/user.controller";
-import { admin, auth } from "../middleware/auth";
+import { auth, authorizeRoles } from "../middleware/auth";
 import validateGitHubToken from "../middleware/validate-github-token";
+import { USER_PERMISSIONS } from "../types/user";
 
 export function userRoutes(app: Express) {
   const router = express.Router();
@@ -100,7 +101,7 @@ export function userRoutes(app: Express) {
    *                         description: Date when a user is created
    *                         example: 2023-03-08T13:42:08.699Z
    */
-  router.get("/", auth, admin, users.findAll);
+  router.get("/", auth, authorizeRoles([USER_PERMISSIONS.ADMIN]), users.findAll);
 
   // Retrieve a single User by their public profile (Github username)
   /**
@@ -283,7 +284,7 @@ export function userRoutes(app: Express) {
    *            type: String
    *            example: Cannot update User with id=1.
    */
-  router.put("/:id", auth, admin, users.update);
+  router.put("/:id", auth, authorizeRoles([USER_PERMISSIONS.ADMIN]), users.update);
 
   app.use("/api/users", router);
 }

--- a/api/app/routes/user.routes.ts
+++ b/api/app/routes/user.routes.ts
@@ -11,9 +11,25 @@ export function userRoutes(app: Express) {
 
   /**
    * @swagger
-   * /api/users:
+   * /api/users/signin:
    *   post:
-   *     summary: Create a JSONPlaceholder user.
+   *     security:
+   *        - apiKeyAuth: []
+   *     tags: [Users]
+   *     summary: Creates or signs in a user.
+   *     description: Creates or signs in a user. If the user is already in the database, the user is signed in. If the user is not in the database, the user is created and signed in.
+   *     requestBody:
+   *      required: true
+   *      content:
+   *        application/json:
+   *          schema:
+   *            type: object
+   *            properties:
+   *              email:
+   *                type: string
+   *                description: The user's Github email.
+   *                example: example@email.com
+   *                required: true
    *     responses:
    *       200:
    *         description: Successfully signed in
@@ -22,17 +38,20 @@ export function userRoutes(app: Express) {
    *             schema:
    *               type: object
    *               properties:
-   *                 data:
-   *                   type: object
-   *                   properties:
-   *                     username:
-   *                       type: string
-   *                       description: The user's github username.
-   *                       example: glozow
-   *                     permissions:
-   *                       type: string
-   *                       description: The user's permissions.
-   *                       enum: [admin, reviewer]
+   *                    jwt:
+   *                      type: string
+   *                      description: The user's JWT token.
+   *                      example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImVtYWlsIjoiZXhhbXBsZUBlbWFpbC5jb20iLCJwZXJtaXNzaW9ucyI6ImFkbWluIiwiaWF0IjoxNjI5MjIwNjI4LCJleHAiOjE2MjkzMDcxMjh9.
+   *       500:
+   *         description: An error occurred while signing in.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                  message:
+   *                   type: string
+   *                   example: Unable to sign in. Some error occurred while signing in.
    */
    router.post("/signin", validateGitHubToken, users.signIn);
   
@@ -42,8 +61,11 @@ export function userRoutes(app: Express) {
    * @swagger
    * /api/users:
    *   get:
-   *     summary: Retrieve a list of JSONPlaceholder users.
-   *     description: Retrieve a list of users from JSONPlaceholder. Can be used to populate a list of fake users when prototyping or testing an API.
+   *     security:
+   *      - bearerAuth: []
+   *     tags: [Users]
+   *     summary: Retrieve a list of users.
+   *     description: Retrieve a list of users. Accessible only to admins. The data returned exculdes the user's JWT token, email, and updatedAt date.
    *     responses:
    *       200:
    *         description: A list of users.
@@ -65,10 +87,6 @@ export function userRoutes(app: Express) {
    *                         type: string
    *                         description: The user's Github username.
    *                         example: ryanofsky
-   *                       authToken:
-   *                         type: string
-   *                         description: The user's authentication token.
-   *                         example: Thsdfk3j3kflfjdkfjfj
    *                       permissions:
    *                         type: string
    *                         description: The user's permissions.
@@ -81,10 +99,6 @@ export function userRoutes(app: Express) {
    *                         type: datetime
    *                         description: Date when a user is created
    *                         example: 2023-03-08T13:42:08.699Z
-   *                       updatedAt:
-   *                         type: datetime
-   *                         description: Date when a user record is updated.
-   *                         example: 2023-03-08T13:42:08.699Z
    */
   router.get("/", auth, admin, users.findAll);
 
@@ -93,15 +107,22 @@ export function userRoutes(app: Express) {
    * @swagger
    * /api/users/public:
    *   get:
-   *     summary: Retrieve a single JSONPlaceholder user.
-   *     description: Retrieve a single JSONPlaceholder user.
-   *     parameters:
-   *       - in: query
-   *         name: username
-   *         required: true
-   *         schema:
-   *            type: string
-   *         description: The user's github username.
+   *     security:
+   *       - bearerAuth: []
+   *     tags: [Users]
+   *     summary: Retrieve a single user by their username.
+   *     description: Retrieve a single user by their username. The data returned is limited to the user's Github username, permissions, and archivedAt date.
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *          schema:
+   *           type: object
+   *           properties:
+   *            username:
+   *              type: string
+   *              description: The user's Github username.
+   *              example: ryanofsky
    *     responses:
    *       200:
    *         description: A single user.
@@ -141,13 +162,16 @@ export function userRoutes(app: Express) {
    * @swagger
    * /api/users/{id}:
    *   get:
-   *     summary: Retrieve a single JSONPlaceholder user.
-   *     description: Retrieve a single JSONPlaceholder user. Can be used to populate a user profile when prototyping or testing an API.
+   *     security:
+   *      - bearerAuth: []
+   *     tags: [Users]
+   *     summary: Retrieve a single user.
+   *     description: Retrieve a single user. Returns all user data.
    *     parameters:
    *       - in: path
    *         name: id
    *         required: true
-   *         description: Numeric ID of the user to retrieve.
+   *         description: ID of the user to retrieve.
    *         schema:
    *           type: integer
    *     responses:

--- a/api/app/routes/user.routes.ts
+++ b/api/app/routes/user.routes.ts
@@ -113,17 +113,13 @@ export function userRoutes(app: Express) {
    *     tags: [Users]
    *     summary: Retrieve a single user by their username.
    *     description: Retrieve a single user by their username. The data returned is limited to the user's Github username, permissions, and archivedAt date.
-   *     requestBody:
-   *       required: true
-   *       content:
-   *         application/json:
-   *          schema:
-   *           type: object
-   *           properties:
-   *            username:
-   *              type: string
-   *              description: The user's Github username.
-   *              example: ryanofsky
+   *     parameters:
+   *       - in: query
+   *         name: username
+   *         schema:
+   *          type: string
+   *          description: The user's Github username.
+   *          example: ryanofsky
    *     responses:
    *       200:
    *         description: A single user.

--- a/api/app/types/user.ts
+++ b/api/app/types/user.ts
@@ -1,6 +1,7 @@
 export enum USER_PERMISSIONS {
   REVIEWER = "reviewer",
   ADMIN = "admin",
+  EVALUATOR = "evaluator",
 }
 
 export interface UserAttributes {
@@ -9,6 +10,6 @@ export interface UserAttributes {
   email: string;
   jwt?: string | null;
   albyToken?: string;
-  permissions: "reviewer" | "admin";
+  permissions: USER_PERMISSIONS;
   archivedAt?: Date | null;
 }

--- a/api/server.ts
+++ b/api/server.ts
@@ -54,6 +54,21 @@ const options = {
         url: serverUrl,
       },
     ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          in: "header",
+          bearerFormat: "JWT",
+        },
+        apiKeyAuth: {
+          type: "apiKey",
+          in: "header",
+          name: "x-github-token",
+        },
+      },
+    },
   },
   apis: ["./app/routes/*.ts"],
 };


### PR DESCRIPTION
This pr adds a new role to the user permissions enum. It follows the issue described here https://github.com/bitcointranscripts/transcription-review-backend/issues/290

This PR also cleans up the user section of the swagger docs since the code touches the user route. Previously, the docs didn't account for the JWT bearer token appended to the headers and the signing route doesn't work in Swagger due to the absence of an API key implementation. 