### PR TITLE
fix: offset calculation in getAllTransactions

### DIFF
--- a/api/app/controllers/transaction.controller.ts
+++ b/api/app/controllers/transaction.controller.ts
@@ -178,7 +178,7 @@ export const getAllTransactions = async (req: Request, res: Response) => {
   const userSearch = req.query.user as string;
   const page: number = Number(req.query.page) || DB_START_PAGE;
   const limit: number = Number(req.query.limit) || DB_TXN_QUERY_LIMIT;
-  const offset: number = page * limit;
+  const offset = (page - 1) * limit;
 
   const txnCondition: {
     transactionStatus?: TRANSACTION_STATUS;
@@ -269,7 +269,7 @@ export const getAllTransactions = async (req: Request, res: Response) => {
     const response = {
       totalTransactions: transactionCount,
       totalPages,
-      page: page + 1,
+      page: page || DB_START_PAGE,
       itemsPerPage: limit,
       hasNextPage,
       hasPreviousPage,


### PR DESCRIPTION
The offset calculation in the `getAllTransactions` function was incorrect, resulting in incorrect pagination of transactions from the db.

Using `const offset: number = page * limit;` doesn't work correctly for pagination because it does not properly account for the zero-based index of pages. Pagination typically requires starting at offset 0 for the first page, offset 1 for the second page, and so on.

The correct offset calculation for pagination is `const offset = (page - 1) * limit;`. This ensures that:

- Page 1 starts at offset 0
- Page 2 starts at offset `limit`
- Page 3 starts at offset `2 * limit`
and so on.